### PR TITLE
Fix gcovr reports on legacy ubuntu 10 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -509,6 +509,8 @@ endif()
 if(NOT CXX_FLAG_CXX11)
 # Maybe the old name will work? c++0x is a deprecated name but if we're on an old compiler we need to use it
     CHECK_ENABLE_CXX_FLAG(CXX_FLAG_CXX0x --std=c++0x)
+# On gcc4.1, we get "cc1plus: warning: -Wuninitialized is not supported without -O" if this isn't added.
+    CHECK_ENABLE_CXX_FLAG(CXX_FLAG_TEST -O)
 endif()
 
 if(CXX_FLAG_CXX11 OR CXX_FLAG_CXX0x)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,48 +130,16 @@ add_custom_command(
     COMMENT "Generating hash function SPI classes..."
     )
 
-set(ACCP_SRC
-        src/com/amazon/corretto/crypto/provider/AccessibleByteArrayOutputStream.java
-        src/com/amazon/corretto/crypto/provider/AesGcmSpi.java
-        src/com/amazon/corretto/crypto/provider/ConstantTime.java
-        src/com/amazon/corretto/crypto/provider/DebugFlag.java
-        src/com/amazon/corretto/crypto/provider/EcGen.java
-        src/com/amazon/corretto/crypto/provider/EvpHmac.java
-        src/com/amazon/corretto/crypto/provider/EvpKeyAgreement.java
-        src/com/amazon/corretto/crypto/provider/EvpKey.java
-        src/com/amazon/corretto/crypto/provider/EvpEcKey.java
-        src/com/amazon/corretto/crypto/provider/EvpEcPublicKey.java
-        src/com/amazon/corretto/crypto/provider/EvpEcPrivateKey.java
-        src/com/amazon/corretto/crypto/provider/EvpRsaKey.java
-        src/com/amazon/corretto/crypto/provider/EvpRsaPublicKey.java
-        src/com/amazon/corretto/crypto/provider/EvpRsaPrivateKey.java
-        src/com/amazon/corretto/crypto/provider/EvpRsaPrivateCrtKey.java
-        src/com/amazon/corretto/crypto/provider/EvpKeyFactory.java
-        src/com/amazon/corretto/crypto/provider/EvpKeyType.java
-        src/com/amazon/corretto/crypto/provider/EvpSignature.java
-        src/com/amazon/corretto/crypto/provider/EvpSignatureBase.java
-        src/com/amazon/corretto/crypto/provider/EvpSignatureRaw.java
-        src/com/amazon/corretto/crypto/provider/EcUtils.java
-        src/com/amazon/corretto/crypto/provider/ExtraCheck.java
-        src/com/amazon/corretto/crypto/provider/InputBuffer.java
-        src/com/amazon/corretto/crypto/provider/Janitor.java
-        src/com/amazon/corretto/crypto/provider/LibCryptoRng.java
-        src/com/amazon/corretto/crypto/provider/Loader.java
-        src/com/amazon/corretto/crypto/provider/AmazonCorrettoCryptoProvider.java
-        src/com/amazon/corretto/crypto/provider/NativeResource.java
-        src/com/amazon/corretto/crypto/provider/MiscInterfaces.java
-        src/com/amazon/corretto/crypto/provider/ReflectiveTools.java
-        src/com/amazon/corretto/crypto/provider/RsaCipher.java
-        src/com/amazon/corretto/crypto/provider/RsaGen.java
-        src/com/amazon/corretto/crypto/provider/RuntimeCryptoException.java
-        src/com/amazon/corretto/crypto/provider/SelfTestFailureException.java
-        src/com/amazon/corretto/crypto/provider/SelfTestResult.java
-        src/com/amazon/corretto/crypto/provider/SelfTestStatus.java
-        src/com/amazon/corretto/crypto/provider/SelfTestSuite.java
-        src/com/amazon/corretto/crypto/provider/ServiceProviderFactory.java
-        src/com/amazon/corretto/crypto/provider/Utils.java
-        ${GENERATED_JAVA_SRC}
-)
+# NOTE: CMake introduced the CONFIGURE_DEPENDS feature in 3.12, so condition
+#       its use on CMake version. If the feature is not available, you may need
+#       to `touch CMakeLists.txt` after adding/removing files for them to be
+#       detected by CMake.
+if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    file(GLOB ACCP_SRC "src/com/amazon/corretto/crypto/provider/*.java")
+else()
+    file(GLOB ACCP_SRC CONFIGURE_DEPENDS "src/com/amazon/corretto/crypto/provider/*.java")
+endif()
+set(ACCP_SRC ${ACCP_SRC} ${GENERATED_JAVA_SRC})
 
 set(BASE_JAVA_COMPILE_FLAGS ${CMAKE_JAVA_COMPILE_FLAGS} -h "${JNI_HEADER_DIR}" -Werror -Xlint)
 
@@ -553,59 +521,21 @@ target_link_libraries(amazonCorrettoCryptoProvider Threads::Threads)
 # Take a dependency on our libcrypto.so file
 target_link_libraries(amazonCorrettoCryptoProvider ${OPENSSL_CRYPTO_LIBRARY})
 
+# NOTE: CMake introduced the CONFIGURE_DEPENDS feature in 3.12, so condition
+#       its use on CMake version. If the feature is not available, you may need
+#       to `touch CMakeLists.txt` after adding/removing files for them to be
+#       detected by CMake.
+if (${CMAKE_VERSION} VERSION_LESS "3.12.0")
+    file(GLOB_RECURSE ACCP_TEST_SRC "tst/com/amazon/corretto/crypto/provider/*.java")
+else()
+    file(GLOB_RECURSE ACCP_TEST_SRC CONFIGURE_DEPENDS "tst/com/amazon/corretto/crypto/provider/*.java")
+endif()
+
+
 ## Tests
 add_jar(
     tests-code-jar
-    SOURCES
-        tst/com/amazon/corretto/crypto/provider/test/AccessibleByteArrayOutputStreamTest.java
-        tst/com/amazon/corretto/crypto/provider/test/AESGenerativeTest.java
-        tst/com/amazon/corretto/crypto/provider/test/AesTest.java
-        tst/com/amazon/corretto/crypto/provider/test/ConstantTimeTests.java
-        tst/com/amazon/corretto/crypto/provider/test/EcGenTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpKeyAgreementSpecificTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpSignatureSpecificTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpSignatureTest.java
-        tst/com/amazon/corretto/crypto/provider/test/HashFunctionTester.java
-        tst/com/amazon/corretto/crypto/provider/test/HmacTest.java
-        tst/com/amazon/corretto/crypto/provider/test/InputBufferTest.java
-        tst/com/amazon/corretto/crypto/provider/test/JanitorTest.java
-        tst/com/amazon/corretto/crypto/provider/test/EvpKeyFactoryTest.java
-        tst/com/amazon/corretto/crypto/provider/test/LibCryptoRngTest.java
-        tst/com/amazon/corretto/crypto/provider/test/MD5Test.java
-        tst/com/amazon/corretto/crypto/provider/test/MiscSingleThreadedTests.java
-        tst/com/amazon/corretto/crypto/provider/test/NativeTestHooks.java
-        tst/com/amazon/corretto/crypto/provider/test/NativeTest.java
-        tst/com/amazon/corretto/crypto/provider/test/RecursiveInitializationTest.java
-        tst/com/amazon/corretto/crypto/provider/test/RsaCipherTest.java
-        tst/com/amazon/corretto/crypto/provider/test/RsaGenTest.java
-        tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyTester.java
-        tst/com/amazon/corretto/crypto/provider/test/SecurityPropertyRecursiveTester.java
-        tst/com/amazon/corretto/crypto/provider/test/SHA1Test.java
-        tst/com/amazon/corretto/crypto/provider/test/SHA256Test.java
-        tst/com/amazon/corretto/crypto/provider/test/SHA384Test.java
-        tst/com/amazon/corretto/crypto/provider/test/SHA512Test.java
-        tst/com/amazon/corretto/crypto/provider/test/SecurityManagerTest.java
-        tst/com/amazon/corretto/crypto/provider/test/SelfTestSuiteTest.java
-        tst/com/amazon/corretto/crypto/provider/test/ServiceSelfTestMetaTest.java
-        tst/com/amazon/corretto/crypto/provider/test/TestProviderInstallation.java
-        tst/com/amazon/corretto/crypto/provider/test/TestResultLogger.java
-        tst/com/amazon/corretto/crypto/provider/test/TestUtil.java
-        tst/com/amazon/corretto/crypto/provider/test/ThrowingRunnable.java
-        tst/com/amazon/corretto/crypto/provider/test/UtilsTest.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/CustomTrustManager.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/ExternalHTTPSIntegrationTest.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/HTTPSTestParameters.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/LocalHTTPSIntegrationTest.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/TestCertificateGenerator.java
-        tst/com/amazon/corretto/crypto/provider/test/integration/TestHTTPSServer.java
-        # Not tests, but things we need related to tests
-        tst/com/amazon/corretto/crypto/provider/test/AESBench.java
-        tst/com/amazon/corretto/crypto/provider/test/Benchmark.java
-        tst/com/amazon/corretto/crypto/provider/coverage/ReportGenerator.java
-        tst/com/amazon/corretto/crypto/provider/test/RspTestEntry.java
-        tst/com/amazon/corretto/crypto/provider/test/SecureRandomGenerator.java
-
+    SOURCES ${ACCP_TEST_SRC}
     INCLUDE_JARS ${TEST_CLASSPATH_LIST} code-only-jar
 )
 set_target_properties(tests-code-jar PROPERTIES EXCLUDE_FROM_ALL 1)

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -25,10 +25,13 @@ ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto/
 RUN echo 'export JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto/' >> /home/.bashrc
 
 # required dependencies for building/testing
+RUN apt-get update
 RUN apt-get install -y build-essential
 RUN apt-get install -y cmake
 RUN apt-get install -y dieharder
 RUN apt-get install -y lcov
+RUN apt-get install -y python3-pip
+RUN pip3 install gcovr
 
 # developement niceties
 RUN apt-get install -y ninja-build

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Building this provider requires a 64 bit Linux build system with the following p
 * [cmake](https://cmake.org/) 3.8 or newer
 * C++ build chain
 * [lcov](http://ltp.sourceforge.net/coverage/lcov.php) for coverage metrics
+* [gcovr](https://gcovr.com/en/stable/) for reporting coverage metrics in CodeBuild
 * [dieharder](http://webhome.phy.duke.edu/~rgb/General/dieharder.php) for entropy tests
 
 1. Download the repository via `git clone --recurse-submodules`

--- a/build.gradle
+++ b/build.gradle
@@ -435,7 +435,6 @@ task coverage_cmake(type: Exec) {
         args '-DSINGLE_TEST=' + System.properties['SINGLE_TEST']
 
     }
-
 }
 
 task coverage_exec(type: Exec) {
@@ -480,6 +479,11 @@ task coverage_cpp_report {
             workingDir "${buildDir}/cmake-coverage"
             commandLine 'lcov', '-e', "${buildDir}/cmake-coverage/coverage.info", 'csrc/*', '--rc', 'lcov_branch_coverage=1'
             standardOutput = new FileOutputStream("${buildDir}/reports/cpp/coverage.info")
+        }
+        exec {
+            workingDir "${buildDir}/cmake-coverage"
+            commandLine 'gcovr', '-r', "${projectDir}", '--cobertura-pretty'
+            standardOutput = new FileOutputStream("${buildDir}/reports/cpp/cobertura.xml")
         }
         exec {
              workingDir projectDir

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,22 @@ version = '2.0.0'
 ext.isFips = Boolean.getBoolean('FIPS')
 
 def awslcSrcPath = "${projectDir}/aws-lc/"
-def cmakeBin = System.properties['cmakeBin'] != null ? System.properties['cmakeBin'] : "cmake";
+
+// Execute cmake3 command to see if it exists. Mainly to support AL2.
+def detect_cmake3 = {
+    def exec_cmake3 = exec {
+        executable "bash" args "-l", "-c", 'command -v cmake3'
+        ignoreExitValue true
+        standardOutput = new ByteArrayOutputStream()
+        errorOutput = standardOutput
+    }
+    if(exec_cmake3.getExitValue() == 0) {
+        return "cmake3"
+    }
+    return "cmake"
+}
+
+def cmakeBin = detect_cmake3()
 
 ext.isJceSigned = { pathToJar ->
     def stdout = new ByteArrayOutputStream()

--- a/build.gradle
+++ b/build.gradle
@@ -112,19 +112,43 @@ task buildAwsLc {
     }
 
     doLast {
-        exec {
-            workingDir awslcSrcPath
-            executable cmakeBin
-            args "-B${cMakeBuildDir}"
-            args '-DBUILD_SHARED_LIBS=ON'
-            args '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
-            args "-DCMAKE_INSTALL_PREFIX=${sharedObjectOutDir}"
-            args "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+        // TODO: Remove this when we finally deprecate gcc4.1.2/Cmake 3.9 internally.
+        // Behavior of how older versions of Cmake take in the the build and source
+        // directory arguments is slightly different.
+        // FIPS isn't tested for this dimension. The only thing we care about for the
+        // legacy build is non C++11 and CMake 3.9 compatibility.
+        if (Boolean.getBoolean('LEGACY_BUILD')) {
+            exec {
+                workingDir cMakeBuildDir
+                executable cmakeBin
+                args "-DBUILD_TESTING=OFF"
+                args "-DBUILD_LIBSSL=OFF"
+                args "-DCMAKE_BUILD_TYPE=Debug"
+                args "-DMY_ASSEMBLER_IS_TOO_OLD_FOR_AVX=ON"
+                args "-std=gnu99"
+                args "-fgnu89-inline"
+                args '-DBUILD_SHARED_LIBS=ON'
+                args "-DCMAKE_INSTALL_PREFIX=${sharedObjectOutDir}"
+                args "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
 
-            if (isFips) {
-                args '-DFIPS=1'
+                args "${awslcSrcPath}"
             }
-            args '.'
+        }
+        else {
+            exec {
+                workingDir awslcSrcPath
+                executable cmakeBin
+                args "-B${cMakeBuildDir}"
+                args '-DBUILD_SHARED_LIBS=ON'
+                args '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
+                args "-DCMAKE_INSTALL_PREFIX=${sharedObjectOutDir}"
+                args "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
+
+                if (isFips) {
+                    args '-DFIPS=1'
+                }
+                args '.'
+            }
         }
         exec {
             workingDir awslcSrcPath
@@ -194,6 +218,10 @@ task executeCmake(type: Exec) {
     if (prebuiltJar != null) {
        args '-DSIGNED_JAR=' + prebuiltJar
        print "Using SIGNED_JAR=${prebuiltJar}"
+    }
+
+    if (System.properties['JAVA_HOME'] != null) {
+        args '-DJAVA_HOME=' + System.properties['JAVA_HOME']
     }
 
     if (System.properties['TEST_JAVA_HOME'] != null) {
@@ -397,6 +425,10 @@ task coverage_cmake(type: Exec) {
     args "-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON"
     if (isFips) {
         args "-DFIPS=ON"
+    }
+
+    if (System.properties['JAVA_HOME'] != null) {
+        args '-DJAVA_HOME=' + System.properties['JAVA_HOME']
     }
 
     if (System.properties['SINGLE_TEST'] != null) {

--- a/build.gradle
+++ b/build.gradle
@@ -482,7 +482,7 @@ task coverage_cpp_report {
         }
         exec {
             workingDir "${buildDir}/cmake-coverage"
-            commandLine 'gcovr', '-r', "${projectDir}", '--cobertura-pretty'
+            commandLine 'gcovr', '-r', "${projectDir}", '--xml'
             standardOutput = new FileOutputStream("${buildDir}/reports/cpp/cobertura.xml")
         }
         exec {

--- a/csrc/env.h
+++ b/csrc/env.h
@@ -64,7 +64,8 @@ class java_ex {
         { }
 
         java_ex(const char *java_classname, const char *message) COLD
-            : java_ex(java_classname, std::string(message)) {
+            : m_java_exception(nullptr), m_java_classname(java_classname), m_message(std::string(message)) {
+            capture_trace();
         }
 
         java_ex(const char *java_classname, const std::string &message) COLD

--- a/tests/ci/cdk/cdk/codebuild/pr_integration_linux_arm_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/pr_integration_linux_arm_omnibus.yaml
@@ -66,6 +66,65 @@ batch:
         variables:
           TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto
 
+    - identifier: amazonlinux2_gcc7x_corretto8_pr_arm
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto11_pr_arm
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto17_pr_arm
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto8_test_integration_arm
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto11_test_integration_arm
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto17_test_integration_arm
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.aarch64
 
     # ACCP FIPS dimensions.
     - identifier: ubuntu2004_gcc7x_corretto8_pr_arm_fips
@@ -127,3 +186,63 @@ batch:
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_arm_latest
         variables:
           TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto
+
+    - identifier: amazonlinux2_gcc7x_corretto8_pr_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto11_pr_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto17_pr_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto8_test_integration_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto11_test_integration_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto.aarch64
+
+    - identifier: amazonlinux2_gcc7x_corretto17_test_integration_arm_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: ARM_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_arm_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.aarch64

--- a/tests/ci/cdk/cdk/codebuild/pr_integration_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/pr_integration_linux_x86_omnibus.yaml
@@ -126,6 +126,15 @@ batch:
         variables:
           TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.x86_64
 
+    # Test non-C++11 support.
+    - identifier: ubuntu1004_gcc4_1x_corretto11_pr_x86
+      buildspec: ./tests/ci/codebuild/run_accp_legacy_build.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:ubuntu-10.04_gcc-4.1x_corretto_x86_latest
+
     # ACCP FIPS dimensions.
     - identifier: ubuntu2004_gcc7x_corretto8_pr_x86_fips
       buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml

--- a/tests/ci/cdk/cdk/codebuild/pr_integration_linux_x86_omnibus.yaml
+++ b/tests/ci/cdk/cdk/codebuild/pr_integration_linux_x86_omnibus.yaml
@@ -66,6 +66,65 @@ batch:
         variables:
           TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto
 
+    - identifier: amazonlinux2_gcc7x_corretto8_pr_x86
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto11_pr_x86
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto17_pr_x86
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto8_test_integration_x86
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto11_test_integration_x86
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto17_test_integration_x86
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.x86_64
 
     # ACCP FIPS dimensions.
     - identifier: ubuntu2004_gcc7x_corretto8_pr_x86_fips
@@ -127,3 +186,63 @@ batch:
         image: ECR_REPO_PLACEHOLDER:ubuntu-20.04_gcc-7x_corretto_x86_latest
         variables:
           TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto
+
+    - identifier: amazonlinux2_gcc7x_corretto8_pr_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto11_pr_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto17_pr_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_basic_tests_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto8_test_integration_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-1.8.0-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto11_test_integration_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-11-amazon-corretto.x86_64
+
+    - identifier: amazonlinux2_gcc7x_corretto17_test_integration_x86_fips
+      buildspec: ./tests/ci/codebuild/run_accp_test_integration_fips.yml
+      env:
+        type: LINUX_CONTAINER
+        privileged-mode: false
+        compute-type: BUILD_GENERAL1_LARGE
+        image: ECR_REPO_PLACEHOLDER:amazonlinux-2_gcc-7x_corretto_x86_latest
+        variables:
+          TEST_JAVA_HOME: /usr/lib/jvm/java-17-amazon-corretto.x86_64

--- a/tests/ci/codebuild/release/al2_aarch64_test.yml
+++ b/tests/ci/codebuild/release/al2_aarch64_test.yml
@@ -33,8 +33,8 @@ phases:
       - pwd
       - ls
       # TODO: Do we want to reintroduce dieharder for some configurations?
-      - ./gradlew -DcmakeBin=cmake3 -DFIPS=${FIPS} -DstagingProperties=true test test_extra_checks test_integration test_integration_extra_checks
-      - ./gradlew -DcmakeBin=cmake3 -DFIPS=${FIPS} -DTEST_JAVA_HOME=$JAVA_8_HOME -DTEST_JAVA_MAJOR_VERSION=8 -DstagingProperties=true minimal_clean test test_extra_checks test_integration test_integration_extra_checks
+      - ./gradlew -DFIPS=${FIPS} -DstagingProperties=true test test_extra_checks test_integration test_integration_extra_checks
+      - ./gradlew -DFIPS=${FIPS} -DTEST_JAVA_HOME=$JAVA_8_HOME -DTEST_JAVA_MAJOR_VERSION=8 -DstagingProperties=true minimal_clean test test_extra_checks test_integration test_integration_extra_checks
 artifacts:
   files:
     - 'lib/**/*'

--- a/tests/ci/codebuild/release/al2_x64_test.yml
+++ b/tests/ci/codebuild/release/al2_x64_test.yml
@@ -35,8 +35,8 @@ phases:
       - find ${CODEBUILD_SRC_DIR_Stage_FIPS} -follow
       - find ${CODEBUILD_SRC_DIR_Stage} -follow
       # TODO: Do we want to reintroduce dieharder for some configurations?
-      - ./gradlew -DcmakeBin=cmake3 -DFIPS=${FIPS} -DTEST_JAVA_HOME=$JAVA_8_HOME -DTEST_JAVA_MAJOR_VERSION=8 -DstagingProperties=true test test_extra_checks test_integration test_integration_extra_checks
-      - ./gradlew -DcmakeBin=cmake3 -DFIPS=${FIPS} -DstagingProperties=true minimal_clean test test_extra_checks test_integration test_integration_extra_checks
+      - ./gradlew -DFIPS=${FIPS} -DTEST_JAVA_HOME=$JAVA_8_HOME -DTEST_JAVA_MAJOR_VERSION=8 -DstagingProperties=true test test_extra_checks test_integration test_integration_extra_checks
+      - ./gradlew -DFIPS=${FIPS} -DstagingProperties=true minimal_clean test test_extra_checks test_integration test_integration_extra_checks
 artifacts:
   files:
     - 'lib/**/*'

--- a/tests/ci/codebuild/release/linux_aarch64_build.yml
+++ b/tests/ci/codebuild/release/linux_aarch64_build.yml
@@ -34,7 +34,7 @@ phases:
       - pwd
       - ls
       # Todo: Readd coverage for slower build but higher test coverage
-      - ./gradlew -DcmakeBin=cmake3 -DFIPS=${FIPS} build src_jar javadoc test test_integration
+      - ./gradlew -DFIPS=${FIPS} build src_jar javadoc test test_integration
 artifacts:
   files:
     - 'lib/**/*'

--- a/tests/ci/codebuild/release/linux_x64_build.yml
+++ b/tests/ci/codebuild/release/linux_x64_build.yml
@@ -34,7 +34,7 @@ phases:
       - pwd
       - ls
       # Todo: Readd coverage for slower build but higher test coverage
-      - ./gradlew -DcmakeBin=cmake3 -DFIPS=${FIPS} build src_jar javadoc test test_integration
+      - ./gradlew -DFIPS=${FIPS} build src_jar javadoc test test_integration
 artifacts:
   files:
     - 'lib/**/*'

--- a/tests/ci/codebuild/release/release.yml
+++ b/tests/ci/codebuild/release/release.yml
@@ -34,6 +34,6 @@ phases:
       - pwd
       - ls
       # TODO: Uncomment next line to actually release
-      # - ./gradlew -DcmakeBin=cmake3 -DFIPS=${FIPS} -DstagingProperties=true releaseSonatypeStagingRepository
+      # - ./gradlew -DFIPS=${FIPS} -DstagingProperties=true releaseSonatypeStagingRepository
       # This next no-op task is just a place holder so that we can execute this file safely without releasing
-      - ./gradlew -DcmakeBin=cmake3 -DFIPS=${FIPS} -DstagingProperties=true tasks
+      - ./gradlew -DFIPS=${FIPS} -DstagingProperties=true tasks

--- a/tests/ci/codebuild/run_accp_basic_tests.yml
+++ b/tests/ci/codebuild/run_accp_basic_tests.yml
@@ -13,3 +13,11 @@ reports:
       - 'build/reports/unit-tests/**'
     discard-paths: yes
     file-format: JunitXml
+  java-coverage-report:
+    files:
+      - 'build/cmake-coverage/coverage/results/coverage-report.xml'
+    file-format: 'JACOCOXML'
+  cpp-coverage-report:
+    files:
+      - 'build/reports/cpp/cobertura.xml'
+    file-format: 'COBERTURAXML'

--- a/tests/ci/codebuild/run_accp_basic_tests_fips.yml
+++ b/tests/ci/codebuild/run_accp_basic_tests_fips.yml
@@ -13,3 +13,11 @@ reports:
       - 'build/reports/unit-tests/**'
     discard-paths: yes
     file-format: JunitXml
+  java-coverage-report:
+    files:
+      - 'build/cmake-coverage/coverage/results/coverage-report.xml'
+    file-format: 'JACOCOXML'
+  cpp-coverage-report:
+    files:
+      - 'build/reports/cpp/cobertura.xml'
+    file-format: 'COBERTURAXML'

--- a/tests/ci/codebuild/run_accp_legacy_build.yml
+++ b/tests/ci/codebuild/run_accp_legacy_build.yml
@@ -1,0 +1,9 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - ./gradlew -DLEGACY_BUILD=true -DJAVA_HOME=$JAVA_HOME -DJAVA_MAJOR_VERSION=11 -DTEST_JAVA_HOME=$JAVA_HOME -DENABLE_NATIVE_TEST_HOOKS=ON release

--- a/tests/ci/docker_images/linux-arm/amazonlinux-2_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/amazonlinux-2_accp_base/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM arm64v8/amazonlinux:2
+
+SHELL ["/bin/bash", "-c"]
+
+RUN set -ex && \
+    yum -y update && yum install -y \
+    cmake \
+    cmake3 \
+    make \
+    ninja-build \
+    perl \
+    golang \
+    which \
+    git \
+    ca-certificates \
+    wget \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+# Get lcov from source because AL2 doesn't have support for installing directly.
+RUN wget http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm && \
+    yum localinstall -y lcov-1.14-1.noarch.rpm
+
+ENV GO111MODULE=on

--- a/tests/ci/docker_images/linux-arm/amazonlinux-2_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/amazonlinux-2_accp_base/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex && \
     make \
     ninja-build \
     perl \
+    python3-pip \
     golang \
     which \
     git \
@@ -22,6 +23,8 @@ RUN set -ex && \
     yum clean all && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/yum
+
+RUN pip3 install gcovr
 
 # Get lcov from source because AL2 doesn't have support for installing directly.
 RUN wget http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm && \

--- a/tests/ci/docker_images/linux-arm/amazonlinux-2_gcc-7x_corretto/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/amazonlinux-2_gcc-7x_corretto/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM amazonlinux-2:accp_base-arm
+
+SHELL ["/bin/bash", "-c"]
+
+RUN amazon-linux-extras enable corretto8
+
+# gcc 7.3.1 is the latest version versions `yum --showduplicates list gcc`
+# JRE and JDK tools are separate in Corretto 17.
+RUN set -ex && \
+    yum -y update && yum install -y \
+    gcc \
+    gcc-c++ \
+    java-1.8.0-amazon-corretto-devel \
+    java-11-amazon-corretto \
+    java-17-amazon-corretto \
+    java-17-amazon-corretto-devel && \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+RUN mkdir /accp
+COPY . /accp
+WORKDIR /accp
+
+# run the gradlew script just to install gradle in the image
+RUN ./gradlew --no-daemon generateEclipseClasspath
+
+ENV CC=gcc
+ENV CXX=g++
+ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto.aarch64

--- a/tests/ci/docker_images/linux-arm/build_images.sh
+++ b/tests/ci/docker_images/linux-arm/build_images.sh
@@ -14,3 +14,5 @@ docker build -t ubuntu-20.04:accp_base-arm ubuntu-20.04_accp_base
 # `../../../../` passes in the Dockerfile in this folder but uses the root directory for the context so it has access to
 # our project's gradle script.
 docker build -t ubuntu-20.04:gcc-7x_corretto-arm -f ubuntu-20.04_gcc-7x_corretto/Dockerfile ../../../../
+docker build -t amazonlinux-2:accp_base-arm amazonlinux-2_accp_base
+docker build -t amazonlinux-2:gcc-7x_corretto-arm -f amazonlinux-2_gcc-7x_corretto/Dockerfile ../../../../

--- a/tests/ci/docker_images/linux-arm/push_images.sh
+++ b/tests/ci/docker_images/linux-arm/push_images.sh
@@ -16,3 +16,4 @@ $(aws ecr get-login --no-include-email)
 
 # Tag images with date to help find old images, CodeBuild uses the latest tag and gets updated automatically
 tag_and_push_img 'ubuntu-20.04:gcc-7x_corretto-arm' "${ECS_REPO}:ubuntu-20.04_gcc-7x_corretto_arm"
+tag_and_push_img 'amazonlinux-2:gcc-7x_corretto-arm' "${ECS_REPO}:amazonlinux-2_gcc-7x_corretto_arm"

--- a/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-arm/ubuntu-20.04_accp_base/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get install -y cmake
 RUN apt-get install -y dieharder
 RUN apt-get install -y lcov
 RUN apt-get install -y wget
+RUN apt-get install -y python3-pip
+RUN pip3 install gcovr
 
 # developement niceties
 RUN apt-get install -y ninja-build

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_accp_base/Dockerfile
@@ -12,6 +12,7 @@ RUN set -ex && \
     make \
     ninja-build \
     perl \
+    python3-pip \
     golang \
     which \
     git \
@@ -22,6 +23,8 @@ RUN set -ex && \
     yum clean all && \
     rm -rf /tmp/* && \
     rm -rf /var/cache/yum
+
+RUN pip3 install gcovr
 
 # Get lcov from source because AL2 doesn't have support for installing directly.
 RUN wget http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm && \

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_accp_base/Dockerfile
@@ -1,0 +1,30 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM amazonlinux:2
+
+SHELL ["/bin/bash", "-c"]
+
+RUN set -ex && \
+    yum -y update && yum install -y \
+    cmake \
+    cmake3 \
+    make \
+    ninja-build \
+    perl \
+    golang \
+    which \
+    git \
+    ca-certificates \
+    wget \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+# Get lcov from source because AL2 doesn't have support for installing directly.
+RUN wget http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm && \
+    yum localinstall -y lcov-1.14-1.noarch.rpm
+
+ENV GO111MODULE=on

--- a/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x_corretto/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/amazonlinux-2_gcc-7x_corretto/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM amazonlinux-2:accp_base
+
+SHELL ["/bin/bash", "-c"]
+
+RUN amazon-linux-extras enable corretto8
+
+# gcc 7.3.1 is the latest version versions `yum --showduplicates list gcc`
+# JRE and JDK tools are separate in Corretto 17.
+RUN set -ex && \
+    yum -y update && yum install -y \
+    gcc \
+    gcc-c++ \
+    java-1.8.0-amazon-corretto-devel \
+    java-11-amazon-corretto \
+    java-17-amazon-corretto \
+    java-17-amazon-corretto-devel && \
+    yum clean packages && \
+    yum clean metadata && \
+    yum clean all && \
+    rm -rf /tmp/* && \
+    rm -rf /var/cache/yum
+
+RUN mkdir /accp
+COPY . /accp
+WORKDIR /accp
+
+# run the gradlew script just to install gradle in the image
+RUN ./gradlew --no-daemon generateEclipseClasspath
+
+ENV CC=gcc
+ENV CXX=g++
+ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto.x86_64

--- a/tests/ci/docker_images/linux-x86/build_images.sh
+++ b/tests/ci/docker_images/linux-x86/build_images.sh
@@ -14,3 +14,5 @@ docker build -t ubuntu-20.04:accp_base ubuntu-20.04_accp_base
 # `../../../../` passes in the Dockerfile in this folder but uses the root directory for the context so it has access to 
 # our project's gradle script.
 docker build -t ubuntu-20.04:gcc-7x_corretto -f ubuntu-20.04_gcc-7x_corretto/Dockerfile ../../../../
+docker build -t amazonlinux-2:accp_base amazonlinux-2_accp_base
+docker build -t amazonlinux-2:gcc-7x_corretto -f amazonlinux-2_gcc-7x_corretto/Dockerfile ../../../../

--- a/tests/ci/docker_images/linux-x86/build_images.sh
+++ b/tests/ci/docker_images/linux-x86/build_images.sh
@@ -16,3 +16,9 @@ docker build -t ubuntu-20.04:accp_base ubuntu-20.04_accp_base
 docker build -t ubuntu-20.04:gcc-7x_corretto -f ubuntu-20.04_gcc-7x_corretto/Dockerfile ../../../../
 docker build -t amazonlinux-2:accp_base amazonlinux-2_accp_base
 docker build -t amazonlinux-2:gcc-7x_corretto -f amazonlinux-2_gcc-7x_corretto/Dockerfile ../../../../
+
+#################################################
+# Build legacy docker image that uses gcc 4.1.3 #
+#################################################
+
+./build_legacy_image.sh ubuntu-10.04_gcc-4.1x_corretto

--- a/tests/ci/docker_images/linux-x86/build_legacy_image.sh
+++ b/tests/ci/docker_images/linux-x86/build_legacy_image.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -ex
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+if [ -n "$1" ]; then
+  docker_name="$1"
+else
+  docker_name='ubuntu-10.04_gcc-4.1x_corretto'
+fi
+
+mkdir -p dependencies
+cd dependencies
+
+# The wget version that comes with this docker image is too old to
+# access modern website sources, so we predownload the dependencies
+# outside of the image and pull it in the container.
+wget -O cmake-3.9.6.tar.gz https://cmake.org/files/v3.9/cmake-3.9.6.tar.gz
+wget -O amazon-corretto-11-x64-linux-jdk.deb https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.deb
+wget -O lcov-1.14-1.noarch.rpm http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm
+cd ..
+docker build -t ubuntu-10.04:gcc-4.1x_corretto -f ${docker_name}/Dockerfile ../../../../
+
+# Remove downloaded dependencies.
+sudo rm -rf dependencies
+cd ..

--- a/tests/ci/docker_images/linux-x86/build_legacy_image.sh
+++ b/tests/ci/docker_images/linux-x86/build_legacy_image.sh
@@ -17,6 +17,7 @@ cd dependencies
 wget -O cmake-3.9.6.tar.gz https://cmake.org/files/v3.9/cmake-3.9.6.tar.gz
 wget -O amazon-corretto-11-x64-linux-jdk.deb https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.deb
 wget -O lcov-1.14-1.noarch.rpm http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm
+wget -O gcovr-2.0.tar.gz https://files.pythonhosted.org/packages/57/58/f57a3ab2df4b504156ae440880ce3432c85190e3050c6d8000a59978ef51/gcovr-2.0.tar.gz
 cd ..
 docker build -t ubuntu-10.04:gcc-4.1x_corretto -f ${docker_name}/Dockerfile ../../../../
 

--- a/tests/ci/docker_images/linux-x86/push_images.sh
+++ b/tests/ci/docker_images/linux-x86/push_images.sh
@@ -17,3 +17,4 @@ $(aws ecr get-login --no-include-email)
 # Tag images with date to help find old images, CodeBuild uses the latest tag and gets updated automatically
 tag_and_push_img 'ubuntu-20.04:gcc-7x_corretto' "${ECS_REPO}:ubuntu-20.04_gcc-7x_corretto_x86"
 tag_and_push_img 'amazonlinux-2:gcc-7x_corretto' "${ECS_REPO}:amazonlinux-2_gcc-7x_corretto_x86"
+tag_and_push_img 'ubuntu-10.04:gcc-4.1x_corretto' "${ECS_REPO}:ubuntu-10.04_gcc-4.1x_corretto_x86"

--- a/tests/ci/docker_images/linux-x86/push_images.sh
+++ b/tests/ci/docker_images/linux-x86/push_images.sh
@@ -16,3 +16,4 @@ $(aws ecr get-login --no-include-email)
 
 # Tag images with date to help find old images, CodeBuild uses the latest tag and gets updated automatically
 tag_and_push_img 'ubuntu-20.04:gcc-7x_corretto' "${ECS_REPO}:ubuntu-20.04_gcc-7x_corretto_x86"
+tag_and_push_img 'amazonlinux-2:gcc-7x_corretto' "${ECS_REPO}:amazonlinux-2_gcc-7x_corretto_x86"

--- a/tests/ci/docker_images/linux-x86/ubuntu-10.04_gcc-4.1x_corretto/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-10.04_gcc-4.1x_corretto/Dockerfile
@@ -1,0 +1,57 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:10.04
+
+CMD ["/bin/bash"]
+
+# The following hack is to avoid a problem where glibc update fails b/c kernel revision is >255
+# https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1962225
+RUN mv /bin/uname /bin/uname.orig
+RUN printf '#!/bin/bash\n\nif [[ "$1" == "-r" ]] ;then\n echo '4.9.250'\n exit\nelse\n uname.orig "$@"\nfi' > /bin/uname
+RUN chmod 755 /bin/uname
+
+RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releases.ubuntu.com/g' /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install \
+    gcc-4.1 \
+    g++-4.1 \
+    make \
+    perl \
+    java-common \
+    alien
+
+RUN update-alternatives --install /usr/bin/cc gcc /usr/bin/gcc-4.1 70 --slave /usr/bin/c++ g++ /usr/bin/g++-4.1 --slave /usr/bin/gcov gcov /usr/bin/gcov-4.1
+
+ENV CC=gcc-4.1
+ENV CXX=g++-4.1
+
+# Pull lcov as an external source since the wget version
+# on this image is too old to access the lcov source.
+COPY tests/ci/docker_images/linux-x86/dependencies/lcov-1.14-1.noarch.rpm /tmp/lcov-1.14-1.noarch.rpm
+RUN cd /tmp && \
+    alien lcov-1.14-1.noarch.rpm && \
+    dpkg --install lcov_1.14-2_all.deb
+
+# Pull cmake as an external source since the wget version
+# on this image is too old to access the cmake repo.
+COPY tests/ci/docker_images/linux-x86/dependencies/cmake-3.9.6.tar.gz /tmp/cmake-3.9.6.tar.gz
+RUN cd /tmp && \
+    tar -xvf cmake-3.9.6.tar.gz && \
+    cd cmake-3.9.6 && \
+    ./configure && make && make install
+
+# Pull Amazon corretto as an external source and install.
+COPY tests/ci/docker_images/linux-x86/dependencies/amazon-corretto-11-x64-linux-jdk.deb /tmp/amazon-corretto-11-x64-linux-jdk.deb
+RUN cd /tmp && \
+    dpkg --install amazon-corretto-11-x64-linux-jdk.deb
+
+RUN mkdir /accp
+COPY . /accp
+WORKDIR /accp
+
+# run the gradlew script just to install gradle in the image
+RUN ./gradlew --no-daemon generateEclipseClasspath
+
+ENV JAVA_HOME=/usr/lib/jvm/java-11-amazon-corretto
+ENV PATH=$JAVA_HOME/bin:/usr/local/bin:$PATH

--- a/tests/ci/docker_images/linux-x86/ubuntu-10.04_gcc-4.1x_corretto/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-10.04_gcc-4.1x_corretto/Dockerfile
@@ -18,6 +18,7 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     g++-4.1 \
     make \
     perl \
+    python-pip \
     java-common \
     alien
 
@@ -32,6 +33,11 @@ COPY tests/ci/docker_images/linux-x86/dependencies/lcov-1.14-1.noarch.rpm /tmp/l
 RUN cd /tmp && \
     alien lcov-1.14-1.noarch.rpm && \
     dpkg --install lcov_1.14-2_all.deb
+
+# Pull gcovr as an external pip package due to obsolete wget.
+COPY tests/ci/docker_images/linux-x86/dependencies/gcovr-2.0.tar.gz /tmp/gcovr-2.0.tar.gz
+RUN cd /tmp && \
+    pip install /tmp/gcovr-2.0.tar.gz
 
 # Pull cmake as an external source since the wget version
 # on this image is too old to access the cmake repo.

--- a/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-20.04_accp_base/Dockerfile
@@ -17,6 +17,8 @@ RUN apt-get install -y cmake
 RUN apt-get install -y dieharder
 RUN apt-get install -y lcov
 RUN apt-get install -y wget
+RUN apt-get install -y python3-pip
+RUN pip3 install gcovr
 
 # developement niceties
 RUN apt-get install -y ninja-build

--- a/tests/ci/run_accp_basic_tests.sh
+++ b/tests/ci/run_accp_basic_tests.sh
@@ -25,7 +25,7 @@ version=$($TEST_JAVA_HOME/bin/java -version 2>&1 | head -1 | cut -d'"' -f2 | sed
 # The JDK version should be least 10 for a regular ACCP build. We can
 # still test on older versions with the TEST_JAVA_HOME property.
 if (( "$version" <= "10" )); then
-	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips test
+	./gradlew -DTEST_JAVA_HOME=$TEST_JAVA_HOME -DTEST_JAVA_MAJOR_VERSION=$version -DFIPS=$testing_fips coverage test
 	exit $?
 fi
 


### PR DESCRIPTION
Ubuntu 10 is very outdated, so we have to work around some constraints.
Firstly, while python3.1 is available on ubuntu 10 via `apt-get`, pip3
is not. So, we need to use legacy pip. Secondly, that legacy pip can't
install packages over the network so we need to download the tarball as
a copied dependency and install it from the filesystem (as we do with
other packages in that build). Finally, only gcovr 2.0 will build on
our legacy ubuntu image (we use gcovr 5.x elsewhere), so we need to
switch to using the `--xml` output configuration flag. Thankfully,
`--cobertura` in later versions is just an alias to `--xml`, so we can
use the same flag across versions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
