### PR TITLE
Fix gcovr reports on legacy ubuntu 10 build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -482,7 +482,7 @@ task coverage_cpp_report {
         }
         exec {
             workingDir "${buildDir}/cmake-coverage"
-            commandLine 'gcovr', '-r', "${projectDir}", '--cobertura-pretty'
+            commandLine 'gcovr', '-r', "${projectDir}", '--xml'
             standardOutput = new FileOutputStream("${buildDir}/reports/cpp/cobertura.xml")
         }
         exec {

--- a/tests/ci/docker_images/linux-x86/build_legacy_image.sh
+++ b/tests/ci/docker_images/linux-x86/build_legacy_image.sh
@@ -17,6 +17,7 @@ cd dependencies
 wget -O cmake-3.9.6.tar.gz https://cmake.org/files/v3.9/cmake-3.9.6.tar.gz
 wget -O amazon-corretto-11-x64-linux-jdk.deb https://corretto.aws/downloads/latest/amazon-corretto-11-x64-linux-jdk.deb
 wget -O lcov-1.14-1.noarch.rpm http://downloads.sourceforge.net/ltp/lcov-1.14-1.noarch.rpm
+wget -O gcovr-2.0.tar.gz https://files.pythonhosted.org/packages/57/58/f57a3ab2df4b504156ae440880ce3432c85190e3050c6d8000a59978ef51/gcovr-2.0.tar.gz
 cd ..
 docker build -t ubuntu-10.04:gcc-4.1x_corretto -f ${docker_name}/Dockerfile ../../../../
 

--- a/tests/ci/docker_images/linux-x86/ubuntu-10.04_gcc-4.1x_corretto/Dockerfile
+++ b/tests/ci/docker_images/linux-x86/ubuntu-10.04_gcc-4.1x_corretto/Dockerfile
@@ -18,6 +18,7 @@ RUN sed -i -re 's/([a-z]{2}\.)?archive.ubuntu.com|security.ubuntu.com/old-releas
     g++-4.1 \
     make \
     perl \
+    python-pip \
     java-common \
     alien
 
@@ -32,6 +33,11 @@ COPY tests/ci/docker_images/linux-x86/dependencies/lcov-1.14-1.noarch.rpm /tmp/l
 RUN cd /tmp && \
     alien lcov-1.14-1.noarch.rpm && \
     dpkg --install lcov_1.14-2_all.deb
+
+# Pull gcovr as an external pip package due to obsolete wget.
+COPY tests/ci/docker_images/linux-x86/dependencies/gcovr-2.0.tar.gz /tmp/gcovr-2.0.tar.gz
+RUN cd /tmp && \
+    pip install /tmp/gcovr-2.0.tar.gz
 
 # Pull cmake as an external source since the wget version
 # on this image is too old to access the cmake repo.

--- a/tst/com/amazon/corretto/crypto/provider/test/integration/CustomTrustManager.java
+++ b/tst/com/amazon/corretto/crypto/provider/test/integration/CustomTrustManager.java
@@ -57,7 +57,8 @@ class CustomTrustManager implements X509TrustManager {
         for (X509Certificate cert: chain) {
             final Date notAfter = cert.getNotAfter();
             final String subjectName = cert.getSubjectX500Principal().getName(X500Principal.RFC2253);
-            if (subjectName.contains(".badssl.com,") && notAfter.before(now)) {
+            if ((subjectName.contains(".badssl.com,") || subjectName.endsWith(".badssl.com"))
+                    && notAfter.before(now)) {
                 getLogger("CustomTrustManager").warning(String.format("%s has expired as of %s. Skipping validation.",
                         subjectName, notAfter));
                 return;


### PR DESCRIPTION
Ubuntu 10 is very outdated, so we have to work around some constraints.
Firstly, while python3.1 is available on ubuntu 10 via `apt-get`, pip3
is not. So, we need to use legacy pip. Secondly, that legacy pip can't
install packages over the network so we need to download the tarball as
a copied dependency and install it from the filesystem (as we do with
other packages in that build). Finally, only gcovr 2.0 will build on
our legacy ubuntu image (we use gcovr 5.x elsewhere), so we need to
switch to using the `--xml` output configuration flag. Thankfully,
`--cobertura` in later versions is just an alias to `--xml`, so we can
use the same flag across versions.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
